### PR TITLE
Bumping to version 4.1.0 of ion-js. JSBI as dependency, as it's now a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,25 @@
 {
   "name": "ion-to-json",
-  "version": "2.0.1",
-  "description" : "A utility function that converts Amazon ION to JSON",
+  "version": "4.1.0",
+  "description": "A utility function that converts Amazon ION to JSON",
   "main": "dist/IonToJson.js",
   "types": "dist/IonToJson.d.ts",
   "author": "Koto Jallow <kotojalloh.kj@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "ion-js": "^3.1.2"
+    "ion-js": "^4.1.0",
+    "jsbi": "^3.1.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "prepare" : "npm run build"
+    "prepare": "npm run build"
   },
   "keywords": [
     "node",
     "Amazon Ion",
-    "ion","JSON"
+    "ion",
+    "JSON"
   ],
   "devDependencies": {
     "@types/node": "^12.12.21",


### PR DESCRIPTION
Bumping the version to 4.1.0. It should work out of the box. 

As JSBI is now treated as peer dependency, the package needs to declare it as a dependency.  